### PR TITLE
ci: automate lecture slides deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,66 @@
+name: Deploy lecture slides
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ vars.ORGANIZATION }}/${{ vars.IMAGE_NAME }}
+  GAR_IMAGE: ${{ vars.GAR_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/${{ vars.GAR_REPOSITORY }}/${{ vars.IMAGE_NAME}}
+
+jobs:
+  deploy:
+    name: "Deploy"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the Google Cloud Platform
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: Configure auth to Google Cloud Platform
+        run: gcloud auth configure-docker ${{ vars.GAR_REGION }}-docker.pkg.dev
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.GAR_IMAGE }}
+          tags: latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: lectures
+          image: ${{ env.GAR_IMAGE }}
+          region: ${{ vars.GCR_REGION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:latest
+
+WORKDIR /usr/lectures
+COPY . .
+
+RUN go install golang.org/x/tools/cmd/present@latest
+
+CMD present -http=:8080 -play=false


### PR DESCRIPTION
Resolves #1 

Images are pushed into both Artifact Registry and GitHub Container Registry.
Deployment is, in the end, done via Cloud Run.

The Dockerfile could be polished. A lot of garbage is also left in the container. Consider adding dockerignore?